### PR TITLE
Refactor to Homespun Local Storage Proxy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,8 +9,5 @@ module.exports = {
     browser: true
   },
   rules: {
-  },
-  globals: {
-    'amplify': true
   }
 };

--- a/addon/backends/browser.js
+++ b/addon/backends/browser.js
@@ -1,0 +1,35 @@
+export default class Browser {
+  constructor() {
+    this._store = window.localStorage;
+  }
+
+  setItem(key, value) {
+    this._store.setItem(key, value);
+  }
+
+  getItem(key) {
+    let oldAmplifyItemKey = `__amplify__${key}`;
+    let item = this._store.getItem(oldAmplifyItemKey);
+
+    if (item) {
+      this.removeItem(oldAmplifyItemKey);
+      this.setItem(key, item);
+
+      return item;
+    } else {
+      return this._store.getItem(key);
+    }
+  }
+
+  removeItem(key) {
+    this._store.removeItem(key);
+  }
+
+  clear() {
+    this._store.clear();
+  }
+
+  get length() {
+    return this._store.length;
+  }
+}

--- a/addon/backends/in-memory.js
+++ b/addon/backends/in-memory.js
@@ -1,0 +1,25 @@
+export default class InMemory {
+  constructor() {
+    this._store = {};
+  }
+
+  setItem(key, value) {
+    this._store[key] = value;
+  }
+
+  getItem(key) {
+    return this._store[key];
+  }
+
+  removeItem(key) {
+    delete this._store[key];
+  }
+
+  get length() {
+    return Object.keys(this._store).length;
+  }
+
+  clear() {
+    this._store = {};
+  }
+}

--- a/addon/lib/browser-store.js
+++ b/addon/lib/browser-store.js
@@ -1,24 +1,25 @@
+import Storage from '../services/storage';
+
+const storage = Storage.create();
+
 export default {
   sessionName: '_es_session',
 
   setItem(name, value) {
-    return amplify.store(name, value);
+    storage.write(name, value);
+
+    return storage.read(name);
   },
 
   getItem(name) {
-    return amplify.store(name);
+    return storage.read(name);
   },
 
   removeItem(name) {
-    return amplify.store(name, null);
+    return storage.del(name);
   },
 
   clearStore() {
-    let keys = Object.keys(amplify.store());
-
-    for (let i = 0; i < keys.length; i++) {
-      let key = keys[i];
-      amplify.store(key, null);
-    }
-  }
+    storage.clear();
+  },
 };

--- a/addon/services/storage.js
+++ b/addon/services/storage.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+import getAndInitializeBackend from '../utils/get-and-initialize-backend';
+
+const {
+  computed,
+  Service,
+} = Ember;
+
+export default Service.extend({
+  backend: computed(function() {
+    return getAndInitializeBackend();
+  }).readOnly(),
+
+  write(key, value) {
+    this.get('backend').setItem(key, value);
+  },
+
+  read(key) {
+    return this.get('backend').getItem(key);
+  },
+
+  del(key) {
+    return this.get('backend').removeItem(key);
+  },
+
+  clear() {
+    this.get('backend').clear();
+  },
+});

--- a/addon/utils/get-and-initialize-backend.js
+++ b/addon/utils/get-and-initialize-backend.js
@@ -1,0 +1,15 @@
+import InMemoryBackend from '../backends/in-memory';
+import BrowserBackend from '../backends/browser';
+
+export default function getAndInitializeBackend() {
+  try {
+    const tempKey = '$$$test$$$';
+
+    localStorage.setItem(tempKey, 'bar');
+    localStorage.removeItem(tempKey);
+
+    return new BrowserBackend();
+  } catch (_) {
+    return new InMemoryBackend();
+  }
+}

--- a/app/backends/browser.js
+++ b/app/backends/browser.js
@@ -1,0 +1,3 @@
+import Browser from 'browser-store/backends/browser';
+
+export default Browser;

--- a/app/backends/in-memory.js
+++ b/app/backends/in-memory.js
@@ -1,0 +1,3 @@
+import InMemory from 'browser-store/backends/in-memory';
+
+export default InMemory;

--- a/app/lib/browser-store.js
+++ b/app/lib/browser-store.js
@@ -1,3 +1,1 @@
-import BrowserStore from 'browser-store/lib/browser-store';
-
-export default BrowserStore;
+export { default } from 'browser-store/lib/browser-store';

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,1 +1,0 @@
-export { default } from 'browser-store/services/session';

--- a/app/services/storage.js
+++ b/app/services/storage.js
@@ -1,0 +1,1 @@
+export { default } from 'browser-store/services/storage';

--- a/app/utils/get-and-initialize-backend.js
+++ b/app/utils/get-and-initialize-backend.js
@@ -1,0 +1,1 @@
+export { default } from 'browser-store/utils/get-and-initialize-backend';

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "browser-store",
   "dependencies": {
-    "amplify": "~1.1.2"
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,17 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'browser-store',
-
-  afterInstall: function() {
-    return this.addBowerPackagesToProject([
-      { name: 'amplify', target: '~1.1.2' },
-    ]);
-  },
-
-  included: function(app) {
-    this._super.included(app);
-
-    app.import(app.bowerDirectory + '/amplify/lib/amplify.store.min.js');
-  }
+  name: 'browser-store'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,6 +211,15 @@
         "repeat-string": "1.6.1"
       }
     },
+    "alter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
+      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
+      "dev": true,
+      "requires": {
+        "stable": "0.1.6"
+      }
+    },
     "amd-name-resolver": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.7.tgz",
@@ -405,6 +414,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "ast-traverse": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
+      "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY=",
       "dev": true
     },
     "ast-types": {
@@ -642,6 +657,18 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-constant-folding": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
+      "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4=",
+      "dev": true
+    },
+    "babel-plugin-dead-code-elimination": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
+      "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U=",
+      "dev": true
+    },
     "babel-plugin-debug-macros": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
@@ -658,10 +685,87 @@
         "ember-rfc176-data": "0.2.7"
       }
     },
+    "babel-plugin-eval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
+      "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo=",
+      "dev": true
+    },
     "babel-plugin-htmlbars-inline-precompile": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz",
       "integrity": "sha1-zTZeJ4r0Cb+mvncExDVL7udCRGs=",
+      "dev": true
+    },
+    "babel-plugin-inline-environment-variables": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
+      "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4=",
+      "dev": true
+    },
+    "babel-plugin-jscript": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
+      "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w=",
+      "dev": true
+    },
+    "babel-plugin-member-expression-literals": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
+      "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM=",
+      "dev": true
+    },
+    "babel-plugin-property-literals": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
+      "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY=",
+      "dev": true
+    },
+    "babel-plugin-proto-to-assign": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
+      "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
+      "dev": true,
+      "requires": {
+        "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-react-constant-elements": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
+      "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o=",
+      "dev": true
+    },
+    "babel-plugin-react-display-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
+      "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw=",
+      "dev": true
+    },
+    "babel-plugin-remove-console": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
+      "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c=",
+      "dev": true
+    },
+    "babel-plugin-remove-debugger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
+      "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc=",
+      "dev": true
+    },
+    "babel-plugin-runtime": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
+      "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8=",
       "dev": true
     },
     "babel-plugin-syntax-async-functions": {
@@ -928,6 +1032,21 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-plugin-undeclared-variables-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+      "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
+      "dev": true,
+      "requires": {
+        "leven": "1.0.2"
+      }
+    },
+    "babel-plugin-undefined-to-void": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
+      "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E=",
+      "dev": true
+    },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
@@ -1174,6 +1293,12 @@
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
       }
+    },
+    "breakable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
+      "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME=",
+      "dev": true
     },
     "broccoli-asset-rev": {
       "version": "2.6.0",
@@ -1972,6 +2097,38 @@
         "graceful-readlink": "1.0.1"
       }
     },
+    "commoner": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+      "dev": true,
+      "requires": {
+        "commander": "2.8.1",
+        "detective": "4.5.0",
+        "glob": "5.0.15",
+        "graceful-fs": "4.1.11",
+        "iconv-lite": "0.4.18",
+        "mkdirp": "0.5.1",
+        "private": "0.1.7",
+        "q": "1.5.0",
+        "recast": "0.11.23"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -2238,6 +2395,58 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "defs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+      "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
+      "dev": true,
+      "requires": {
+        "alter": "0.2.0",
+        "ast-traverse": "0.1.1",
+        "breakable": "1.0.0",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "simple-fmt": "0.1.0",
+        "simple-is": "0.2.0",
+        "stringmap": "0.2.2",
+        "stringset": "0.2.1",
+        "tryor": "0.1.2",
+        "yargs": "3.27.0"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "3.27.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+          "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
+          "dev": true,
+          "requires": {
+            "camelcase": "1.2.1",
+            "cliui": "2.1.0",
+            "decamelize": "1.2.0",
+            "os-locale": "1.4.0",
+            "window-size": "0.1.4",
+            "y18n": "3.2.1"
+          }
+        }
+      }
+    },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
@@ -2286,6 +2495,24 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
         "repeating": "2.0.1"
+      }
+    },
+    "detective": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13",
+        "defined": "1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
       }
     },
     "diff": {
@@ -2869,6 +3096,242 @@
       "dev": true,
       "requires": {
         "recast": "0.11.23"
+      }
+    },
+    "ember-sinon": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ember-sinon/-/ember-sinon-0.7.0.tgz",
+      "integrity": "sha1-Qbg7WxxxYm2ybo/7SlLNq5wDmik=",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "1.2.0",
+        "broccoli-merge-trees": "1.2.4",
+        "ember-cli-babel": "5.2.4",
+        "sinon": "2.4.1"
+      },
+      "dependencies": {
+        "babel-core": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+          "dev": true,
+          "requires": {
+            "babel-plugin-constant-folding": "1.0.1",
+            "babel-plugin-dead-code-elimination": "1.0.2",
+            "babel-plugin-eval": "1.0.1",
+            "babel-plugin-inline-environment-variables": "1.0.1",
+            "babel-plugin-jscript": "1.0.4",
+            "babel-plugin-member-expression-literals": "1.0.1",
+            "babel-plugin-property-literals": "1.0.1",
+            "babel-plugin-proto-to-assign": "1.0.4",
+            "babel-plugin-react-constant-elements": "1.0.3",
+            "babel-plugin-react-display-name": "1.0.3",
+            "babel-plugin-remove-console": "1.0.1",
+            "babel-plugin-remove-debugger": "1.0.1",
+            "babel-plugin-runtime": "1.0.7",
+            "babel-plugin-undeclared-variables-check": "1.0.2",
+            "babel-plugin-undefined-to-void": "1.1.6",
+            "babylon": "5.8.38",
+            "bluebird": "2.11.0",
+            "chalk": "1.1.3",
+            "convert-source-map": "1.5.0",
+            "core-js": "1.2.7",
+            "debug": "2.6.8",
+            "detect-indent": "3.0.1",
+            "esutils": "2.0.2",
+            "fs-readdir-recursive": "0.1.2",
+            "globals": "6.4.1",
+            "home-or-tmp": "1.0.0",
+            "is-integer": "1.0.7",
+            "js-tokens": "1.0.1",
+            "json5": "0.4.0",
+            "lodash": "3.10.1",
+            "minimatch": "2.0.10",
+            "output-file-sync": "1.1.2",
+            "path-exists": "1.0.0",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.7",
+            "regenerator": "0.8.40",
+            "regexpu": "1.3.0",
+            "repeating": "1.1.3",
+            "resolve": "1.4.0",
+            "shebang-regex": "1.0.0",
+            "slash": "1.0.0",
+            "source-map": "0.5.7",
+            "source-map-support": "0.2.10",
+            "to-fast-properties": "1.0.3",
+            "trim-right": "1.0.1",
+            "try-resolve": "1.0.1"
+          }
+        },
+        "babylon": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "dev": true
+        },
+        "broccoli-babel-transpiler": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.2.tgz",
+          "integrity": "sha512-vFQ+aSR9J81fm3MXXQGgDxswYINHl2p5duLvRLVnpmgPDNdpdsa30gh3xnmhzR/GwWFBfUNle7aYxthlgvsN0w==",
+          "dev": true,
+          "requires": {
+            "babel-core": "5.8.38",
+            "broccoli-funnel": "1.2.0",
+            "broccoli-merge-trees": "1.2.4",
+            "broccoli-persistent-filter": "1.4.3",
+            "clone": "0.2.0",
+            "hash-for-dep": "1.2.0",
+            "heimdalljs-logger": "0.1.9",
+            "json-stable-stringify": "1.0.1",
+            "rsvp": "3.6.2",
+            "workerpool": "2.2.4"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+              "dev": true
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
+          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "can-symlink": "1.0.0",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "heimdalljs-logger": "0.1.9",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8"
+          }
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "repeating": "1.1.3"
+          }
+        },
+        "ember-cli-babel": {
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz",
+          "integrity": "sha1-XOT0awjtb20h6Hhhn7aJcZ1ujhM=",
+          "dev": true,
+          "requires": {
+            "broccoli-babel-transpiler": "5.7.2",
+            "broccoli-funnel": "1.2.0",
+            "clone": "2.1.1",
+            "ember-cli-version-checker": "1.3.1",
+            "resolve": "1.4.0"
+          }
+        },
+        "globals": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+          "dev": true
+        },
+        "home-or-tmp": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2",
+            "user-home": "1.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
+          "dev": true
+        },
+        "json5": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+          "dev": true
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.1.32"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        }
       }
     },
     "ember-source": {
@@ -3819,6 +4282,15 @@
         "for-in": "1.0.2"
       }
     },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.2.1"
+      }
+    },
     "forwarded": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
@@ -3858,6 +4330,12 @@
           }
         }
       }
+    },
+    "fs-readdir-recursive": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
+      "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk=",
+      "dev": true
     },
     "fs-tree-diff": {
       "version": "0.5.6",
@@ -5181,6 +5659,12 @@
         "loose-envify": "1.3.1"
       }
     },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
@@ -5259,6 +5743,15 @@
       "dev": true,
       "requires": {
         "is-extglob": "1.0.0"
+      }
+    },
+    "is-integer": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
+      "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
       }
     },
     "is-number": {
@@ -5494,6 +5987,15 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
     },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
     "leek": {
       "version": "0.0.24",
       "resolved": "https://registry.npmjs.org/leek/-/leek-0.0.24.tgz",
@@ -5504,6 +6006,12 @@
         "lodash.assign": "3.2.0",
         "rsvp": "3.6.2"
       }
+    },
+    "leven": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
+      "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -6005,6 +6513,12 @@
         "lodash.keys": "2.3.0"
       }
     },
+    "lolex": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+      "dev": true
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -6285,6 +6799,12 @@
       "dev": true,
       "optional": true
     },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6490,6 +7010,15 @@
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
@@ -6509,6 +7038,17 @@
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
+      }
+    },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
       }
     },
     "p-finally": {
@@ -6736,6 +7276,12 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "q": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+      "dev": true
+    },
     "qs": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
@@ -6960,6 +7506,46 @@
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
       "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
     },
+    "regenerator": {
+      "version": "0.8.40",
+      "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+      "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
+      "dev": true,
+      "requires": {
+        "commoner": "0.10.8",
+        "defs": "1.1.1",
+        "esprima-fb": "15001.1001.0-dev-harmony-fb",
+        "private": "0.1.7",
+        "recast": "0.10.33",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.8.12",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
+          "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w=",
+          "dev": true
+        },
+        "esprima-fb": {
+          "version": "15001.1001.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+          "dev": true
+        },
+        "recast": {
+          "version": "0.10.33",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+          "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
+          "dev": true,
+          "requires": {
+            "ast-types": "0.8.12",
+            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "private": "0.1.7",
+            "source-map": "0.5.7"
+          }
+        }
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
@@ -6982,6 +7568,53 @@
       "dev": true,
       "requires": {
         "is-equal-shallow": "0.1.3"
+      }
+    },
+    "regexpu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+      "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
+      "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "recast": "0.10.43",
+        "regenerate": "1.3.2",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.8.15",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
+          "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI=",
+          "dev": true
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "recast": {
+          "version": "0.10.43",
+          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
+          "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
+          "dev": true,
+          "requires": {
+            "ast-types": "0.8.15",
+            "esprima-fb": "15001.1001.0-dev-harmony-fb",
+            "private": "0.1.7",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "esprima-fb": {
+              "version": "15001.1001.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+              "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "regexpu-core": {
@@ -7154,6 +7787,12 @@
       "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
       "dev": true
     },
+    "samsam": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+      "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+      "dev": true
+    },
     "sane": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-1.7.0.tgz",
@@ -7283,11 +7922,56 @@
       "integrity": "sha1-BmPRDxVW8VAFUdUY9W46ughxNx0=",
       "dev": true
     },
+    "simple-fmt": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
+      "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms=",
+      "dev": true
+    },
     "simple-html-tokenizer": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.4.1.tgz",
       "integrity": "sha1-AomIu3/osuZkVnbYIFJYfUQLAtM=",
       "dev": true
+    },
+    "simple-is": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
+      "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA=",
+      "dev": true
+    },
+    "sinon": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+      "dev": true,
+      "requires": {
+        "diff": "3.3.1",
+        "formatio": "1.2.0",
+        "lolex": "1.6.0",
+        "native-promise-only": "0.8.1",
+        "path-to-regexp": "1.7.0",
+        "samsam": "1.2.1",
+        "text-encoding": "0.6.4",
+        "type-detect": "4.0.3"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -7547,6 +8231,12 @@
       "integrity": "sha1-p/6lw/3lXmdc8cjAbz67XCk1g14=",
       "dev": true
     },
+    "stable": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
+      "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -7575,6 +8265,18 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "stringmap": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
+      "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE=",
+      "dev": true
+    },
+    "stringset": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
+      "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -7775,6 +8477,12 @@
         "xmldom": "0.1.27"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -7859,10 +8567,22 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
+    "try-resolve": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
+      "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI=",
+      "dev": true
+    },
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "tryor": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
+      "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys=",
       "dev": true
     },
     "type-check": {
@@ -7873,6 +8593,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.15",
@@ -7964,6 +8690,12 @@
       "requires": {
         "os-homedir": "1.0.2"
       }
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
     },
     "username-sync": {
       "version": "1.0.1",
@@ -8142,6 +8874,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
+    "ember-sinon": "^0.7.0",
     "ember-source": "~2.15.0",
     "loader.js": "^4.2.3"
   },

--- a/tests/unit/backends/browser-test.js
+++ b/tests/unit/backends/browser-test.js
@@ -1,0 +1,97 @@
+import Browser from 'dummy/backends/browser';
+import { module, test } from 'qunit';
+
+module('Unit | Backends | Browser', {
+  afterEach() {
+    window.localStorage.clear();
+  },
+});
+
+test('setItem', function(assert) {
+  let subject = new Browser();
+
+  subject.setItem('foo', 'bar');
+
+  let directValue = window.localStorage.getItem('foo');
+
+  assert.equal(
+    directValue,
+    'bar',
+    'writes to the local storage'
+  );
+});
+
+test('getItem', function(assert) {
+  let subject = new Browser();
+
+  subject.setItem('foo', 'bar');
+
+  let value = subject.getItem('foo');
+
+  assert.equal(
+    value,
+    'bar',
+    'retrieves a value from the store'
+  );
+});
+
+test('retrieving an item previously stored by amplify', function(assert) {
+  let subject = new Browser();
+  let key = 'foo';
+  let storedValue = 'bar';
+
+  window.localStorage.setItem(`__amplify__${key}`, storedValue);
+
+  let value = subject.getItem(key);
+
+  assert.equal(
+    value,
+    storedValue,
+    'retrieves the value previously stored by amplify'
+  );
+
+  let valueAtOldKey = window.localStorage.getItem(`__amplify__${key}`);
+
+  assert.notOk(
+    valueAtOldKey,
+    'destroys the value at the old amplify key'
+  );
+
+  let valueAtNewKey = window.localStorage.getItem(key);
+
+  assert.equal(
+    valueAtNewKey,
+    storedValue,
+    'stores the value at the new key'
+  );
+});
+
+test('removeItem', function(assert) {
+  let subject = new Browser();
+
+  subject.setItem('foo', 'bar');
+
+  subject.removeItem('foo');
+
+  let value = subject.getItem('foo');
+
+  assert.equal(
+    value,
+    null,
+    'removes an item from storage'
+  );
+});
+
+test('clear', function(assert) {
+  let subject = new Browser();
+
+  subject.setItem('foo', 'bar');
+
+  subject.clear();
+
+  assert.equal(
+    subject.length,
+    0,
+    'clears the storage'
+  );
+});

--- a/tests/unit/backends/in-memory-test.js
+++ b/tests/unit/backends/in-memory-test.js
@@ -1,0 +1,84 @@
+import InMemory from 'dummy/backends/in-memory';
+import { module, test } from 'qunit';
+
+module('Unit | Backends | In Memory');
+
+test('initialization', function(assert) {
+  let subject = new InMemory();
+
+  let store = subject._store;
+
+  assert.equal(
+    typeof store,
+    'object'
+  );
+
+  assert.equal(
+    Object.keys(store).length,
+    0,
+    'is an empty object'
+  );
+});
+
+test('setItem', function(assert) {
+  let subject = new InMemory();
+
+  subject.setItem('foo', 'bar');
+
+  let store = subject._store;
+
+  assert.equal(
+    store.foo,
+    'bar',
+    'writes the value to its storage'
+  );
+});
+
+test('getItem', function(assert) {
+  let subject = new InMemory();
+
+  subject.setItem('foo', 'bar');
+
+  let value = subject.getItem('foo');
+
+  assert.equal(
+    value,
+    'bar',
+    'retrieves a value from the store'
+  );
+});
+
+test('removeItem', function(assert) {
+  let subject = new InMemory();
+
+  subject.setItem('foo', 'bar');
+
+  subject.removeItem('foo');
+
+  let value = subject.getItem('foo');
+
+  assert.equal(
+    value,
+    null,
+    'removes the value from the store'
+  );
+});
+
+test('clear', function(assert) {
+  let subject = new InMemory();
+
+  subject.setItem('foo', 'bar');
+
+  assert.equal(
+    subject.length,
+    1
+  );
+
+  subject.clear();
+
+  assert.equal(
+    subject.length,
+    0,
+    'removes all items from storage'
+  );
+});

--- a/tests/unit/lib/browser-store-test.js
+++ b/tests/unit/lib/browser-store-test.js
@@ -1,5 +1,8 @@
 import BrowserStore from 'browser-store/lib/browser-store';
 import { module, test } from 'qunit';
+import Storage from 'dummy/services/storage';
+
+const storage = Storage.create();
 
 module('BrowserStore');
 
@@ -9,7 +12,7 @@ test('#setItem', function(assert) {
 
   BrowserStore.setItem(key, expectedValue);
 
-  let actualValue = amplify.store(key);
+  let actualValue = storage.read(key);
 
   assert.equal(actualValue, expectedValue, 'should set a value into the browser localStorage');
 });
@@ -18,7 +21,7 @@ test('#getItem', function(assert) {
   let key = 'myKey';
   let expectedValue = 'myValue';
 
-  amplify.store(key, expectedValue);
+  storage.write(key, expectedValue);
 
   let actualValue = BrowserStore.getItem(key);
 

--- a/tests/unit/services/storage-test.js
+++ b/tests/unit/services/storage-test.js
@@ -1,0 +1,94 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:storage', 'Unit | Service | storage', {
+});
+
+test('backend is initialized', function(assert) {
+  let service = this.subject();
+
+  assert.ok(
+    !!service.get('backend'),
+  );
+});
+
+test('backend cannot be written to', function(assert) {
+  let service = this.subject();
+
+  assert.throws(function() {
+    service.set('backend', 'foo');
+  });
+});
+
+test('backend can be written to', function(assert) {
+  let service = this.subject();
+  let backend = service.get('backend');
+
+  try {
+    service.write('foo', 'bar');
+
+    assert.equal(
+      backend.getItem('foo'),
+      'bar'
+    );
+  } finally {
+    backend.clear();
+  }
+});
+
+test('backend can be read from', function(assert) {
+  let service = this.subject();
+  let backend = service.get('backend');
+
+  try {
+    service.write('foo', 'bar');
+
+    let value = service.read('foo');
+
+    assert.equal(
+      value,
+      'bar'
+    );
+  } finally {
+    backend.clear();
+  }
+});
+
+test('backend can be wiped clean', function(assert) {
+  let service = this.subject();
+  let backend = service.get('backend');
+
+  try {
+    service.write('foo', 'bar');
+
+    service.clear();
+
+    let value = service.read('foo');
+
+    assert.equal(
+      value,
+      null
+    );
+  } finally {
+    backend.clear();
+  }
+});
+
+test('backend can delete key', function(assert) {
+  let service = this.subject();
+  let backend = service.get('backend');
+
+  try {
+    service.write('foo', 'bar');
+
+    service.del('foo');
+
+    let value = service.read('foo');
+
+    assert.equal(
+      value,
+      null
+    );
+  } finally {
+    backend.clear();
+  }
+});

--- a/tests/unit/utils/get-and-initialize-backend-test.js
+++ b/tests/unit/utils/get-and-initialize-backend-test.js
@@ -1,0 +1,40 @@
+import getAndInitializeBackend from 'dummy/utils/get-and-initialize-backend';
+import BrowserBackend from 'dummy/backends/browser';
+import InMemoryBackend from 'dummy/backends/in-memory';
+import sinon from 'sinon';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | get and initialize backend');
+
+test('when setting to local storage works', function(assert) {
+  let backend = getAndInitializeBackend();
+
+  assert.ok(
+    backend instanceof BrowserBackend,
+    'is the browser backend proxy'
+  );
+});
+
+test('when setting to local storage throws', function(assert) {
+  try {
+    sinon.stub(window.localStorage, 'setItem').callsFake(function () {
+      throw 'quota exceeded, like in Private Safari';
+    });
+
+    let backend = getAndInitializeBackend();
+
+    assert.ok(
+      backend instanceof InMemoryBackend,
+      'uses in-memory backend'
+    );
+  } catch (err) {
+    assert.ok(
+      false,
+      'something bad happened'
+    );
+
+    throw err;
+  } finally {
+    window.localStorage.setItem.restore();
+  }
+});


### PR DESCRIPTION
There's no good reason to use amplify. It's heavy, it's a bower
dependency, and it's pretty clear how to replace it with our own
solution.

Going forward the ideal way to access storage is through the "storage"
service. Please see its implementation for details. A `BrowserStore` lib
is provided for backward compatibility.

Speaking of backward compatibility, we can read and migrate old amplify
keys and values.